### PR TITLE
Implement more sophisticated ContrastLIME objective

### DIFF
--- a/contrastlime/lime_base.py
+++ b/contrastlime/lime_base.py
@@ -189,8 +189,11 @@ class LimeBase(object):
             model_regressor = Ridge(alpha=1, fit_intercept=True,
                                     random_state=self.random_state)
         easy_model = model_regressor
-        easy_model.fit(neighborhood_data[:, used_features],
-                       labels_column, sample_weight=weights)
+        if 0 in labels_column:
+            print("Warn: replacing 0s with small positive values for Tweedie regression")
+            labels_column = np.where(labels_column == 0, 1e1-5, labels_column)
+
+        easy_model.fit(neighborhood_data[:, used_features], labels_column, sample_weight=weights)
         prediction_score = easy_model.score(
             neighborhood_data[:, used_features],
             labels_column, sample_weight=weights)

--- a/contrastlime/lime_base.py
+++ b/contrastlime/lime_base.py
@@ -141,7 +141,8 @@ class LimeBase(object):
                                    label,
                                    num_features,
                                    feature_selection='auto',
-                                   model_regressor=None):
+                                   model_regressor=None,
+                                   regressor_requires_positive_values=False):
         """Takes perturbed data, labels and distances, returns explanation.
 
         Args:
@@ -189,8 +190,8 @@ class LimeBase(object):
             model_regressor = Ridge(alpha=1, fit_intercept=True,
                                     random_state=self.random_state)
         easy_model = model_regressor
-        if 0 in labels_column:
-            print("Warn: replacing 0s with small positive values for Tweedie regression")
+        if regressor_requires_positive_values and 0 in labels_column:
+            print("Warn: replacing 0s with small positive values.")
             labels_column = np.where(labels_column == 0, 1e1-5, labels_column)
 
         easy_model.fit(neighborhood_data[:, used_features], labels_column, sample_weight=weights)

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -541,7 +541,8 @@ class LimeTextExplainer(object):
             ret_exp.local_pred[label]) = self.base.explain_instance_with_data(
                 data, yss, distances, label, num_features,
                 model_regressor=model_regressor,
-                feature_selection=self.feature_selection)
+                feature_selection=self.feature_selection,
+                regressor_requires_positive_values=regressor_requires_positive_values)
             ret_exp.dummy_label=0
 
             if regressor_requires_positive_values:

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -676,7 +676,7 @@ class LimeTextExplainer(object):
         assert pred_probs_a.shape == pred_probs_b.shape
         #prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
         #prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
-        prediction_difference = self.squash(np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine])) - 0.5
+        prediction_difference = self.squash(np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]))
         #
 
         # Make the "predicted probability" matrix have two columns: the difference between model A and model B for 

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -606,7 +606,7 @@ class LimeTextExplainer(object):
         return data, labels, distances
 
     @staticmethod
-    def squash(value, tanh_squash_factor=2, squash_threshold=0.25):
+    def squash(value, tanh_squash_factor=2, squash_threshold=0.4):
         # Given value between 0 and 1, push values between 0 and squash_threshold closer to 0, and push
         # values between squash_threshold and 1 closer to 1.
         zero_one_value = (value - squash_threshold) * 2

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -445,7 +445,7 @@ class LimeTextExplainer(object):
                          labels=(1,),
                          top_labels=None,
                          num_features=10,
-                         num_samples=25000,
+                         num_samples=5000,
                          model_names=["Model A", "Model B"],
                          distance_metric='cosine',
                          model_regressor=None,

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -542,6 +542,10 @@ class LimeTextExplainer(object):
                 feature_selection=self.feature_selection)
             ret_exp.dummy_label=0
 
+            # TODO(Vijay): Delete if not using Tweedie
+            ret_exp.score[label] -= 1
+            ret_exp.intercept[label] -= 1
+
         ret_exp.class_names = model_names
         return ret_exp
 
@@ -658,11 +662,12 @@ class LimeTextExplainer(object):
 
         if label_style == "classification":
             contrast_matrix = np.zeros(pred_probs_a.shape)
-            contrast_matrix[:,1] = prediction_difference
-            contrast_matrix[:,0] = -prediction_difference
+            # Add 1.0 to make this a nonnegative output
+            contrast_matrix[:,1] = 1.0 + prediction_difference
+            contrast_matrix[:,0] = 1.0 - prediction_difference
             labels = contrast_matrix
         elif label_style == "regression":
-            labels = prediction_difference
+            labels = 1.0 + prediction_difference
         else:
             raise LimeError('Invalid explanation mode "{}". '
                             'Should be either "classification" '

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -606,12 +606,12 @@ class LimeTextExplainer(object):
         return data, labels, distances
 
     @staticmethod
-    def squash(self, value, tanh_squash_factor=5):
+    def squash(value, tanh_squash_factor=2, squash_decision_boundary=0.4):
         # Given value between 0 and 1, push values between 0 and 0.5 closer to 0, and push
         # values between 0.5 and 1 closer to 1.
-        zero_one_value = value * 2 - 1
+        zero_one_value = (value - squash_decision_boundary) * 2
         squash = np.tanh(tanh_squash_factor * zero_one_value)
-        return (squash + 1) / 2
+        return squash/2 + squash_decision_boundary
 
     def __data_labels_distances_contrast(self,
                                 indexed_string,

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -605,6 +605,14 @@ class LimeTextExplainer(object):
         distances = distance_fn(sp.sparse.csr_matrix(data))
         return data, labels, distances
 
+    @staticmethod
+    def squash(self, value, tanh_squash_factor=5):
+        # Given value between 0 and 1, push values between 0 and 0.5 closer to 0, and push
+        # values between 0.5 and 1 closer to 1.
+        zero_one_value = value * 2 - 1
+        squash = np.tanh(tanh_squash_factor * zero_one_value)
+        return (squash + 1) / 2
+
     def __data_labels_distances_contrast(self,
                                 indexed_string,
                                 classifier_fn_a,
@@ -666,7 +674,11 @@ class LimeTextExplainer(object):
         pred_probs_a = classifier_fn_a(inverse_data)
         pred_probs_b = classifier_fn_b(inverse_data)
         assert pred_probs_a.shape == pred_probs_b.shape
-        prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
+        #prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
+        #prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
+        prediction_difference = self.squash(np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine])) - 0.5
+        #
+
         # Make the "predicted probability" matrix have two columns: the difference between model A and model B for 
         # a desired label, and the difference between model B and model A for the desired label.
 

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -606,10 +606,10 @@ class LimeTextExplainer(object):
         return data, labels, distances
 
     @staticmethod
-    def squash(value, tanh_squash_factor=2, squash_decision_boundary=0.25):
-        # Given value between 0 and 1, push values between 0 and 0.5 closer to 0, and push
-        # values between 0.5 and 1 closer to 1.
-        zero_one_value = (value - squash_decision_boundary) * 2
+    def squash(value, tanh_squash_factor=2, squash_threshold=0.25):
+        # Given value between 0 and 1, push values between 0 and squash_threshold closer to 0, and push
+        # values between squash_threshold and 1 closer to 1.
+        zero_one_value = (value - squash_threshold) * 2
         squashed_value = np.tanh(tanh_squash_factor * zero_one_value)
         return squashed_value/2 + 0.5
 

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -548,8 +548,8 @@ class LimeTextExplainer(object):
             if regressor_requires_positive_values:
                 # Outputs have been adjusted to add 1, so now subtract 1 from
                 # the score and y-intercept.
-                ret_exp.score[label] -= 1
-                ret_exp.intercept[label] -= 1
+                ret_exp.score[label] -= 0.5
+                ret_exp.intercept[label] -= 0.5
 
         ret_exp.class_names = model_names
         return ret_exp
@@ -666,7 +666,7 @@ class LimeTextExplainer(object):
         pred_probs_a = classifier_fn_a(inverse_data)
         pred_probs_b = classifier_fn_b(inverse_data)
         assert pred_probs_a.shape == pred_probs_b.shape
-        prediction_difference = (pred_probs_b - pred_probs_a)[:, label_to_examine]
+        prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
         # Make the "predicted probability" matrix have two columns: the difference between model A and model B for 
         # a desired label, and the difference between model B and model A for the desired label.
 
@@ -676,11 +676,11 @@ class LimeTextExplainer(object):
             contrast_matrix[:,1] = prediction_difference
             contrast_matrix[:,0] = -prediction_difference
             if make_labels_positive:
-                contrast_matrix[:,1] += 1.0
-                contrast_matrix[:,0] += 1.0
+                contrast_matrix[:,1] += 0.5
+                contrast_matrix[:,0] += 0.5
             labels = contrast_matrix
         elif label_style == "regression":
-            labels = 1.0 + prediction_difference
+            labels = 0.5 + prediction_difference
         else:
             raise LimeError('Invalid explanation mode "{}". '
                             'Should be either "classification" '

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -688,7 +688,7 @@ class LimeTextExplainer(object):
                 contrast_matrix[:,0] += 0.5
             labels = contrast_matrix
         elif label_style == "regression":
-            labels = 0.5 + prediction_difference
+            labels = prediction_difference
         else:
             raise LimeError('Invalid explanation mode "{}". '
                             'Should be either "classification" '

--- a/contrastlime/lime_text.py
+++ b/contrastlime/lime_text.py
@@ -606,12 +606,12 @@ class LimeTextExplainer(object):
         return data, labels, distances
 
     @staticmethod
-    def squash(value, tanh_squash_factor=2, squash_decision_boundary=0.4):
+    def squash(value, tanh_squash_factor=2, squash_decision_boundary=0.25):
         # Given value between 0 and 1, push values between 0 and 0.5 closer to 0, and push
         # values between 0.5 and 1 closer to 1.
         zero_one_value = (value - squash_decision_boundary) * 2
-        squash = np.tanh(tanh_squash_factor * zero_one_value)
-        return squash/2 + squash_decision_boundary
+        squashed_value = np.tanh(tanh_squash_factor * zero_one_value)
+        return squashed_value/2 + 0.5
 
     def __data_labels_distances_contrast(self,
                                 indexed_string,
@@ -674,14 +674,10 @@ class LimeTextExplainer(object):
         pred_probs_a = classifier_fn_a(inverse_data)
         pred_probs_b = classifier_fn_b(inverse_data)
         assert pred_probs_a.shape == pred_probs_b.shape
-        #prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
-        #prediction_difference = np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]) - 0.5
         prediction_difference = self.squash(np.abs((pred_probs_b - pred_probs_a)[:, label_to_examine]))
-        #
 
         # Make the "predicted probability" matrix have two columns: the difference between model A and model B for 
         # a desired label, and the difference between model B and model A for the desired label.
-
         if label_style == "classification":
             contrast_matrix = np.zeros(pred_probs_a.shape)
             # Add 1.0 to make this a nonnegative output

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='contrastlime',
-      version='0.2.0.6',
+      version='0.2.0.7',
       description='Contrastive Local Interpretable Model-Agnostic Explanations for comparing machine learning classifiers',
       url='http://github.com/viswavi/lime',
       license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='contrastlime',
-      version='0.2.0.1',
+      version='0.2.0.6',
       description='Contrastive Local Interpretable Model-Agnostic Explanations for comparing machine learning classifiers',
       url='http://github.com/viswavi/lime',
       license='BSD',


### PR DESCRIPTION
New contrastlime objective that seems to work well is to use the standard ridge regression regressor, but with an interesting "loss function": take the absolute difference between the models (to basically predict disagreement), but "squash" its values with tanh such that values less than some threshold go to 0 and values greater than the threshold go to 1